### PR TITLE
Add pageLength to Table button validation set

### DIFF
--- a/Public/Table.ps1
+++ b/Public/Table.ps1
@@ -5,7 +5,7 @@ function Table {
         [Parameter(Mandatory = $false, Position = 1)][ScriptBlock] $PreContent,
         [Parameter(Mandatory = $false, Position = 2)][ScriptBlock] $PostContent,
         [Array] $DataTable,
-        [string[]][ValidateSet('copyHtml5', 'excelHtml5', 'csvHtml5', 'pdfHtml5')] $Buttons = @('copyHtml5', 'excelHtml5', 'csvHtml5', 'pdfHtml5', 'pageLength'),
+        [string[]][ValidateSet('copyHtml5', 'excelHtml5', 'csvHtml5', 'pdfHtml5', 'pageLength')] $Buttons = @('copyHtml5', 'excelHtml5', 'csvHtml5', 'pdfHtml5', 'pageLength'),
         [string[]][ValidateSet('numbers', 'simple', 'simple_numbers', 'full', 'full_numbers', 'first_last_numbers')] $PagingStyle = 'full_numbers',
         [int[]]$PagingOptions = @(15, 25, 50, 100),
         [switch]$DisablePaging,


### PR DESCRIPTION
The call to ValidateSet() for the -Button argument when creating a Table did not include 'pageLength', so when attempting to add the pageLength button it would always fail validation despite it being one of the allowed options.
Adding it to the list allows the button to be created properly instead of failing validation every time. 

Tested on Dashimo 0.0.18 and PowerShell 5.1.14409.1018